### PR TITLE
Fixes for 0.12

### DIFF
--- a/BSDarthMaul/BeatmapDataNoArrowsTransform.cs
+++ b/BSDarthMaul/BeatmapDataNoArrowsTransform.cs
@@ -11,9 +11,10 @@ namespace BSDarthMaul
     {
         public static BeatmapData CreateTransformedData(BeatmapData beatmapData)
         {
+            Console.WriteLine("Transforming");
             bool isDarthModeOn = Plugin.IsDarthModeOn;
             int randLevel = Plugin.NoArrowRandLv;
-            beatmapData = beatmapData.GetCopy();
+            
             BeatmapLineData[] beatmapLinesData = beatmapData.beatmapLinesData;
             int[] array = new int[beatmapLinesData.Length];
             for (int i = 0; i < array.Length; i++)

--- a/BSDarthMaul/DarthMaulBehavior.cs
+++ b/BSDarthMaul/DarthMaulBehavior.cs
@@ -48,17 +48,22 @@ namespace BSDarthMaul
                 //var _mainGameSceneSetup = FindObjectOfType<MainGameSceneSetup>();
                 //_mainGameSceneSetupData = ReflectionUtil.GetPrivateField<MainGameSceneSetupData>(_mainGameSceneSetup, "_mainGameSceneSetupData");
                 levelSetup = Resources.FindObjectsOfTypeAll<StandardLevelSceneSetupDataSO>().FirstOrDefault();
+                GameplayCoreSceneSetup gameplayCoreSceneSetup = Resources.FindObjectsOfTypeAll<GameplayCoreSceneSetup>().First();
 
-                //if (Plugin.IsDarthModeOn && _mainGameSceneSetupData.gameplayMode == GameplayMode.SoloNoArrows)
-                //{
-                //    var _beatmapDataModel = ReflectionUtil.GetPrivateField<BeatmapDataModel>(_mainGameSceneSetup, "_beatmapDataModel");
-                //    var beatmapData = CreateTransformedBeatmapData(_mainGameSceneSetupData.difficultyLevel.beatmapData, _mainGameSceneSetupData.gameplayOptions, _mainGameSceneSetupData.gameplayMode);
-                //    if (beatmapData != null)
-                //    {
-                //        _beatmapDataModel.beatmapData = beatmapData;
-                //        ReflectionUtil.SetPrivateField(_mainGameSceneSetup, "_beatmapDataModel", _beatmapDataModel);
-                //    }
-                //}
+                // For now just check for practice mode 
+
+                if (Plugin.IsDarthModeOn && levelSetup.gameplayCoreSetupData.practiceSettings != null)
+                {
+                   var _beatmapDataModel = ReflectionUtil.GetPrivateField<BeatmapDataModel>(gameplayCoreSceneSetup, "_beatmapDataModel");
+                    var beatmapData = CreateTransformedBeatmapData(levelSetup.difficultyBeatmap.beatmapData.GetCopy(), levelSetup);
+                    if (beatmapData != null)
+                    {
+                        _beatmapDataModel.beatmapData = beatmapData;
+                    
+                    }
+                }
+
+    
             }
             catch (Exception ex)
             {
@@ -166,36 +171,24 @@ namespace BSDarthMaul
             hapticFeedbackHooks.UnHookAll();
         }
 
-        //public static BeatmapData CreateTransformedBeatmapData(BeatmapData beatmapData, GameplayOptions gameplayOptions, GameplayMode gameplayMode)
-        //{
-        //    BeatmapData beatmapData2 = beatmapData;
-        //    if (gameplayOptions.mirror)
-        //    {
-        //        beatmapData2 = BeatDataMirrorTransform.CreateTransformedData(beatmapData2);
-        //    }
-        //    if (gameplayMode == GameplayMode.SoloNoArrows)
-        //    {
-        //        beatmapData2 = BeatmapDataNoArrowsTransform.CreateTransformedData(beatmapData2);
-        //    }
-        //    if (gameplayOptions.obstaclesOption != GameplayOptions.ObstaclesOption.All)
-        //    {
-        //        beatmapData2 = BeatmapDataObstaclesTransform.CreateTransformedData(beatmapData2, gameplayOptions.obstaclesOption);
-        //    }
-        //    if (beatmapData2 == beatmapData)
-        //    {
-        //        beatmapData2 = beatmapData.GetCopy();
-        //    }
-        //    if (gameplayOptions.staticLights)
-        //    {
-        //        BeatmapEventData[] beatmapEventData = new BeatmapEventData[]
-        //        {
-        //        new BeatmapEventData(0f, BeatmapEventType.Event0, 1),
-        //        new BeatmapEventData(0f, BeatmapEventType.Event4, 1)
-        //        };
-        //        beatmapData2 = new BeatmapData(beatmapData2.beatmapLinesData, beatmapEventData);
-        //    }
-        //    return beatmapData2;
-        //}
+        public static BeatmapData CreateTransformedBeatmapData(BeatmapData beatmapData, StandardLevelSceneSetupDataSO levelSetup)
+        {
+            BeatmapData beatmapData2 = beatmapData;
+            
+            if (selectedCharacteristic == "No Arrows")
+            {
+                beatmapData2 = BeatmapDataNoArrowsTransform.CreateTransformedData(beatmapData2);
+            }
+            //This covers all of the modifiers and player settings that were here previously
+            beatmapData2 = BeatDataTransformHelper.CreateTransformedBeatmapData(beatmapData2, levelSetup.gameplayCoreSetupData.gameplayModifiers, levelSetup.gameplayCoreSetupData.practiceSettings, levelSetup.gameplayCoreSetupData.playerSpecificSettings);
+
+            if (beatmapData2 == beatmapData)
+            {
+                beatmapData2 = beatmapData.GetCopy();
+            }
+
+            return beatmapData2;
+        }
 
         public void ToggleDarthMode()
         {

--- a/BSDarthMaul/DarthMaulUI.cs
+++ b/BSDarthMaul/DarthMaulUI.cs
@@ -1,0 +1,46 @@
+﻿using BSDarthMaul.Components;
+using HMUI;
+using PlayHooky;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using UnityEngine;
+using CustomUI.GameplaySettings;
+namespace BSDarthMaul
+{
+    public class DarthMaulUI
+    {
+        public static void CreateUI()
+        {
+            //Haven't added Icons for now, can refer to Github readme for CustomUI for adding icons, hint text is also fairly basic atm
+
+            var darthMaulMenu = GameplaySettingsUI.CreateSubmenuOption(GameplaySettingsPanels.ModifiersRight, "Darth Maul Settings", "MainMenu", "DarthMaulMenu1", "Darth Maul Plugin Options");
+
+            var darthMaulToggle = GameplaySettingsUI.CreateToggleOption(GameplaySettingsPanels.ModifiersRight, "Darth Maul", "DarthMaulMenu1",  "Enable Darth Maul Mode");
+            darthMaulToggle.GetValue = Plugin.IsDarthModeOn;
+            darthMaulToggle.OnToggle += (value) => { Plugin.IsDarthModeOn = value;  };
+
+            var oneHandedToggle = GameplaySettingsUI.CreateToggleOption(GameplaySettingsPanels.ModifiersRight, "One Handed", "DarthMaulMenu1", "One Handed Darth Maul");
+            oneHandedToggle.GetValue = Plugin.IsOneHanded;
+            oneHandedToggle.OnToggle += (value) => { Plugin.IsOneHanded = value; };
+
+            var autoDetectToggle = GameplaySettingsUI.CreateToggleOption(GameplaySettingsPanels.ModifiersRight, "Auto Detect", "DarthMaulMenu1", "Auto Detect seperation/attachment of sabers. No Fail Only");
+            autoDetectToggle.GetValue = Plugin.IsAutoDetect;
+            autoDetectToggle.OnToggle += (value) => { Plugin.IsAutoDetect = value; };
+
+            var leftHandToggle = GameplaySettingsUI.CreateToggleOption(GameplaySettingsPanels.ModifiersRight, "Left Main Controller", "DarthMaulMenu1", "Whether the left controller is the main controller.");
+            leftHandToggle.GetValue = Plugin.MainController == Plugin.ControllerType.LEFT ? true : false; ;
+            leftHandToggle.OnToggle += (value) => { Plugin.MainController = value == true ? Plugin.ControllerType.LEFT : Plugin.ControllerType.RIGHT; };
+
+
+        }
+
+
+
+
+
+
+    }
+}

--- a/BSDarthMaul/Plugin.cs
+++ b/BSDarthMaul/Plugin.cs
@@ -16,7 +16,10 @@ namespace BSDarthMaul
         public string Version => VersionNum;
 
         private static Plugin _instance;
-        
+
+        // Characteristic controller to check what the current mode is
+        private BeatmapCharacteristicSelectionViewController _characteristicViewController;
+        public static string selectedCharacteristic = "Standard";
         //private static PanelBehavior panelBehavior;
         private static DarthMaulBehavior darthMaulBehavior;
 
@@ -115,11 +118,18 @@ namespace BSDarthMaul
         public void OnApplicationStart()
         {
             SceneManager.activeSceneChanged += SceneManagerOnActiveSceneChanged;
+            SceneManager.sceneLoaded += SceneManager_sceneLoaded;
             CheckForUserDataFolder();
             _instance = this;
         }
 
-		public void OnApplicationQuit()
+        private void SceneManager_sceneLoaded(Scene scene, LoadSceneMode arg1)
+        {
+            if(scene.name == "Menu")
+            DarthMaulUI.CreateUI();
+        }
+
+        public void OnApplicationQuit()
 		{
             SceneManager.activeSceneChanged -= SceneManagerOnActiveSceneChanged;
             _instance = null;
@@ -132,14 +142,22 @@ namespace BSDarthMaul
                 Console.WriteLine("scene.name == " + scene.name);
                 if (scene.name == "Menu")
                 {
-                    //panelBehavior = new GameObject("panelBehavior").AddComponent<PanelBehavior>();
-                }
-                else if (scene.name == "GameCore")
+                    if (_characteristicViewController == null)
+                    {
+                        _characteristicViewController = Resources.FindObjectsOfTypeAll<BeatmapCharacteristicSelectionViewController>().FirstOrDefault();
+                        if (_characteristicViewController == null) return;
+                        _characteristicViewController.didSelectBeatmapCharacteristicEvent += _characteristicViewController_didSelectBeatmapCharacteristicEvent;
+                    }
+
+
+                        //panelBehavior = new GameObject("panelBehavior").AddComponent<PanelBehavior>();
+                    }
+                    else if (scene.name == "GameCore")
                 {
                     //if (!loader)
                     //    loader = Resources.FindObjectsOfTypeAll<AsyncScenesLoader>().FirstOrDefault();
                     //loader.loadingDidFinishEvent += OnLoadingDidFinishGame;
-                    OnLoadingDidFinishGame();
+                    SharedCoroutineStarter.instance.StartCoroutine(OnLoadingDidFinishGame());
                 }
             }
             catch (Exception ex)
@@ -148,8 +166,16 @@ namespace BSDarthMaul
             }
         }
 
-        public void OnLoadingDidFinishGame()
+        private void _characteristicViewController_didSelectBeatmapCharacteristicEvent(BeatmapCharacteristicSelectionViewController arg1, BeatmapCharacteristicSO characteristic)
         {
+            //  Standard, One Saber, No Arrows
+
+            selectedCharacteristic = characteristic.characteristicName;
+        }
+
+        public static System.Collections.IEnumerator OnLoadingDidFinishGame()
+        {
+            yield return new WaitForSeconds(0.1f);
             darthMaulBehavior = new GameObject("DarthMaulBehavior").AddComponent<DarthMaulBehavior>();
         }
 


### PR DESCRIPTION
Basic UI setup on gameplay options using BeatSaberCustomUI, fixed no arrows randomization, at least it worked from my testing (Only activates in practice mode when in no arrows mode for now since I'm not sure if maul leaderboards are working and am not super familiar with the plugin in the first place, and wouldn't want scores set playing a map different than the map the leaderboard is for being submitted, regardless of any score reduction)